### PR TITLE
Fix memory leak

### DIFF
--- a/PDFsharp/code/PdfSharp/PdfSharp.Drawing/FontHelper.cs
+++ b/PDFsharp/code/PdfSharp/PdfSharp.Drawing/FontHelper.cs
@@ -181,7 +181,7 @@ namespace PdfSharp.Drawing
 
     public static int GetWpfValue(XFontFamily family, XFontStyle style, GWV value)
     {
-      FontDescriptor descriptor = FontDescriptorStock.Global.CreateDescriptor(family, style);
+      FontDescriptor descriptor = FontDescriptorStock.NewInstance.CreateDescriptor(family, style);
       XFontMetrics metrics = descriptor.FontMetrics;
 
       switch (value)
@@ -220,7 +220,7 @@ namespace PdfSharp.Drawing
     {
 #if !SILVERLIGHT
       // TODOWPF: check for correctness
-      FontDescriptor descriptor = FontDescriptorStock.Global.CreateDescriptor(family, style);
+      FontDescriptor descriptor = FontDescriptorStock.NewInstance.CreateDescriptor(family, style);
       XFontMetrics metrics = descriptor.FontMetrics;
 
       style &= XFontStyle.Regular | XFontStyle.Bold | XFontStyle.Italic | XFontStyle.BoldItalic; // same as XFontStyle.BoldItalic

--- a/PDFsharp/code/PdfSharp/PdfSharp.Drawing/XFont.cs
+++ b/PDFsharp/code/PdfSharp/PdfSharp.Drawing/XFont.cs
@@ -571,7 +571,7 @@ namespace PdfSharp.Drawing
       {
         if (this.fontMetrics == null)
         {
-          FontDescriptor descriptor = FontDescriptorStock.Global.CreateDescriptor(this);
+          FontDescriptor descriptor = FontDescriptorStock.NewInstance.CreateDescriptor(this);
           this.fontMetrics = descriptor.FontMetrics;
         }
         return this.fontMetrics;

--- a/PDFsharp/code/PdfSharp/PdfSharp.Fonts/FontDescriptorStock.cs
+++ b/PDFsharp/code/PdfSharp/PdfSharp.Fonts/FontDescriptorStock.cs
@@ -221,6 +221,14 @@ namespace PdfSharp.Fonts
     }
     static FontDescriptorStock global;
 
+    public static FontDescriptorStock NewInstance
+    {
+      get
+      {
+        return new FontDescriptorStock();
+      }
+    }
+
     Dictionary<FontSelector, FontDescriptor> table;
 
     /// <summary>

--- a/PDFsharp/code/PdfSharp/PdfSharp.Pdf.Advanced/PdfTrueTypeFont.cs
+++ b/PDFsharp/code/PdfSharp/PdfSharp.Pdf.Advanced/PdfTrueTypeFont.cs
@@ -61,7 +61,7 @@ namespace PdfSharp.Pdf.Advanced
       Elements.SetName(Keys.Subtype, "/TrueType");
 
       // TrueType with WinAnsiEncoding only
-      OpenTypeDescriptor ttDescriptor = (OpenTypeDescriptor)FontDescriptorStock.Global.CreateDescriptor(font);
+      OpenTypeDescriptor ttDescriptor = (OpenTypeDescriptor)FontDescriptorStock.NewInstance.CreateDescriptor(font);
       this.fontDescriptor = new PdfFontDescriptor(document, ttDescriptor);
       this.fontOptions = font.PdfOptions;
       Debug.Assert(this.fontOptions != null);

--- a/PDFsharp/code/PdfSharp/PdfSharp.Pdf.Advanced/PdfType0Font.cs
+++ b/PDFsharp/code/PdfSharp/PdfSharp.Pdf.Advanced/PdfType0Font.cs
@@ -58,7 +58,7 @@ namespace PdfSharp.Pdf.Advanced
       Elements.SetName(Keys.Subtype, "/Type0");
       Elements.SetName(Keys.Encoding, vertical ? "/Identity-V" : "/Identity-H");
 
-      OpenTypeDescriptor ttDescriptor = (OpenTypeDescriptor)FontDescriptorStock.Global.CreateDescriptor(font);
+      OpenTypeDescriptor ttDescriptor = (OpenTypeDescriptor)FontDescriptorStock.NewInstance.CreateDescriptor(font);
       this.fontDescriptor = new PdfFontDescriptor(document, ttDescriptor);
       this.fontOptions = font.PdfOptions;
       Debug.Assert(this.fontOptions != null);
@@ -113,7 +113,7 @@ namespace PdfSharp.Pdf.Advanced
       Elements.SetName(Keys.Subtype, "/Type0");
       Elements.SetName(Keys.Encoding, vertical ? "/Identity-V" : "/Identity-H");
 
-      OpenTypeDescriptor ttDescriptor = (OpenTypeDescriptor)FontDescriptorStock.Global.CreateDescriptor(idName, fontData);
+      OpenTypeDescriptor ttDescriptor = (OpenTypeDescriptor)FontDescriptorStock.NewInstance.CreateDescriptor(idName, fontData);
       this.fontDescriptor = new PdfFontDescriptor(document, ttDescriptor);
       this.fontOptions = new XPdfFontOptions(PdfFontEncoding.Unicode, PdfFontEmbedding.Always);
       Debug.Assert(this.fontOptions != null);


### PR DESCRIPTION
- FontDescriptorStock.Global to NewInstance to avoid memory leak while converting many files.